### PR TITLE
Seperate mime type and query to the appropriate variables

### DIFF
--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -152,7 +152,7 @@ t_request Server::request_parser(std::string request) {
 		size_t questionMarkPos = extract.find('?', dotPos);
 		if (questionMarkPos != std::string::npos && questionMarkPos > dotPos) {
 			requestStruct.mime_type = extract.substr(dotPos, questionMarkPos - dotPos);
-			requestStruct.cgiQueryString = extract.substr(questionMarkPos + 1);
+			requestStruct.cgi_query_string = extract.substr(questionMarkPos + 1);
 			requestStruct.uri_path =
 				extract.substr(0, questionMarkPos); // update uri_path without query
 		} else {

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -148,12 +148,13 @@ t_request Server::request_parser(std::string request) {
 	iss >> extract;
 	requestStruct.uri_path = extract;
 	if (extract.find('.') != std::string::npos) {
-		std::cout << extract << "\n";
 		size_t dotPos = extract.find('.');
 		size_t questionMarkPos = extract.find('?', dotPos);
 		if (questionMarkPos != std::string::npos && questionMarkPos > dotPos) {
 			requestStruct.mime_type = extract.substr(dotPos, questionMarkPos - dotPos);
 			requestStruct.cgiQueryString = extract.substr(questionMarkPos + 1);
+			requestStruct.uri_path =
+				extract.substr(0, questionMarkPos); // update uri_path without query
 		} else {
 			requestStruct.mime_type = extract.substr(dotPos);
 		}
@@ -172,8 +173,6 @@ t_request Server::request_parser(std::string request) {
 		else if (extract.find("Connection: ", 0) != std::string::npos)
 			requestStruct.connection = extract.substr(12);
 	}
-	std::cout << "Mime type: " << requestStruct.mime_type << "\n";
-	std::cout << "Uri path: " << requestStruct.uri_path << "\n";
 	return requestStruct;
 }
 

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -147,8 +147,17 @@ t_request Server::request_parser(std::string request) {
 	requestStruct.method = extract;
 	iss >> extract;
 	requestStruct.uri_path = extract;
-	if (extract.find('.') != std::string::npos)
-		requestStruct.mime_type = extract.substr(extract.find('.'));
+	if (extract.find('.') != std::string::npos) {
+		std::cout << extract << "\n";
+		size_t dotPos = extract.find('.');
+		size_t questionMarkPos = extract.find('?', dotPos);
+		if (questionMarkPos != std::string::npos && questionMarkPos > dotPos) {
+			requestStruct.mime_type = extract.substr(dotPos, questionMarkPos - dotPos);
+			requestStruct.cgiQueryString = extract.substr(questionMarkPos + 1);
+		} else {
+			requestStruct.mime_type = extract.substr(dotPos);
+		}
+	}
 	iss >> extract; // we ignore HTTP/1.1 for now
 	while (std::getline(iss, extract) || extract != "\r") {
 		if (extract.empty() || extract == "\r\n") break;
@@ -163,6 +172,8 @@ t_request Server::request_parser(std::string request) {
 		else if (extract.find("Connection: ", 0) != std::string::npos)
 			requestStruct.connection = extract.substr(12);
 	}
+	std::cout << "Mime type: " << requestStruct.mime_type << "\n";
+	std::cout << "Uri path: " << requestStruct.uri_path << "\n";
 	return requestStruct;
 }
 

--- a/Server/ServerRequest.hpp
+++ b/Server/ServerRequest.hpp
@@ -11,6 +11,7 @@ typedef struct s_request {
 	std::string language;  // dont need for now
 	std::string connection;
 	std::string mime_type;	   // format that client can accept in response
+	std::string cgiQueryString;
 
 } t_request;
 

--- a/Server/ServerRequest.hpp
+++ b/Server/ServerRequest.hpp
@@ -11,7 +11,7 @@ typedef struct s_request {
 	std::string language;  // dont need for now
 	std::string connection;
 	std::string mime_type;	   // format that client can accept in response
-	std::string cgiQueryString;
+	std::string cgi_query_string;
 
 } t_request;
 


### PR DESCRIPTION
Changes made:
Now the mime type should be correctly recognized
Add a new variable to accommodate  the query string in cgi request, in this case it's removed from the uri_path.